### PR TITLE
Preserve the current url when changing teams

### DIFF
--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -226,11 +226,13 @@
 
         methods: {
             switchToTeam(team) {
+                const currentUrl = window.location.href
                 this.$inertia.put('/current-team', {
                     'team_id': team.id
                 }, {
                     preserveState: false
                 })
+                window.location = currentUrl
             },
 
             logout() {


### PR DESCRIPTION
This change preserves the current URL of the browser when switching teams so that you don't always return to the Dashboard.vue, but rather the page on which you were on when the team was switched.
